### PR TITLE
Fix: Links to cross-origin destinations are unsafe

### DIFF
--- a/src/components/FixMeNavbar/FixMeNavbar.tsx
+++ b/src/components/FixMeNavbar/FixMeNavbar.tsx
@@ -72,6 +72,7 @@ export default class FixMeNavbar extends React.Component<
                   target="_blank"
                   to="https://twitter.com/fixmeparser"
                   eventLabel="Twitter on menu clicked"
+                  rel="noopener"
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -22,7 +22,7 @@ export const customPageView = (url: string) => {
 
 export const customOutboundLink = (url: string) =>
   develop
-    ? window.open(url, "_blank")
+    ? window.open(url, "_blank", 'noopener')
     : outboundLink({ label: url }, () => {
-        window.open(url, "_blank");
+        window.open(url, "_blank", 'noopener');
       });


### PR DESCRIPTION
Issue: https://github.com/ossn/fixme/issues/17
Fixed the issue by searching for links in the repository and added `noopener` to the OutboundLink. 

