### PR TITLE
Setup corrected to show only when it is defined

### DIFF
--- a/src/routes/Projects/components/Projects.tsx
+++ b/src/routes/Projects/components/Projects.tsx
@@ -65,7 +65,9 @@ export default class Projects extends React.PureComponent<IProjectProps, {}> {
                             {issues_count === 1 ? "issue" : "issues"}
                           </span>
                           <br />
-                          <span className="small">{setup_duration} setup</span>
+                          { 
+                            setup_duration && <span className="small">{setup_duration} setup</span> 
+                          }
                         </div>
                       </div>
                       <div className="d-flex justify-content-between align-items-end projects-tile-bottom-wrapper">


### PR DESCRIPTION
Closes #35
![setup](https://user-images.githubusercontent.com/31198893/47087210-098cee80-d239-11e8-8b1b-fdb6c105456e.png)
Corrected setup to only show up if it is defined