### PR TITLE
Filter sidebar in Issues page made scrollable closes #12

### DIFF
--- a/src/styles/issues.scss
+++ b/src/styles/issues.scss
@@ -115,6 +115,8 @@
   }
   .issues-filter-wrapper {
     display: none;
+    max-height: 800px;
+    overflow-y: hidden;
     @include media-breakpoint-up(md) {
       display: unset;
       @supports (position: sticky) {
@@ -124,8 +126,11 @@
       }
     }
     @include media-breakpoint-up(lg) {
-      margin-left: 3em;
-      margin-right: 3em;
+      margin-left: 1.5em;
+      margin-right: 1.5em;
+    }
+    &:hover {
+      overflow-y: scroll;
     }
   }
   .circle {

--- a/src/styles/issues.scss
+++ b/src/styles/issues.scss
@@ -115,7 +115,7 @@
   }
   .issues-filter-wrapper {
     display: none;
-    max-height: 800px;
+    max-height: 80vh;
     overflow-y: hidden;
     @include media-breakpoint-up(md) {
       display: unset;


### PR DESCRIPTION
Closes #12 
Being irritated by the non-scrollable filters bar on the issues page, decided to solve this issue.
In this pr following changes have been made:
1.max height and overflow added to make the sidebar scrollable
2.side margins reduced so that when the scrollbar appears the options remain on the same line 
Current look of the page:
![scroll](https://user-images.githubusercontent.com/31198893/47178252-425fbd00-d338-11e8-9d74-73e4e2002c8c.png)
