### PR TITLE
Fixed the scroll bug which occured when navigating to issues page from home

### DIFF
--- a/src/routes/Issues/components/Issues.tsx
+++ b/src/routes/Issues/components/Issues.tsx
@@ -64,10 +64,10 @@ const getParamsFromProps = (props: IIssuesProps): IParams => {
         ? [language]
         : language
       : undefined,
-    type: type 
-      ? typeof type === "string" 
-        ? [type] 
-        : type 
+    type: type
+      ? typeof type === "string"
+        ? [type]
+        : type
       : undefined,
     project_id: project_id
       ? typeof project_id === "string"
@@ -76,8 +76,8 @@ const getParamsFromProps = (props: IIssuesProps): IParams => {
       : undefined,
     ordering: ordering
       ? Array.isArray(ordering)
-        ? ordering[0] 
-        : ordering 
+        ? ordering[0]
+        : ordering
       : undefined
   };
 };
@@ -93,6 +93,10 @@ export default class Issues extends React.PureComponent<
   };
 
   public componentDidMount(): void {
+    const scrolltoRoot = document.getElementById('root');
+    if(!!scrolltoRoot){
+      scrolltoRoot.scrollIntoView();
+    }
     this.props.getIssues(this.state.params);
     this.props.getProjects();
     customPageView(window.location.pathname + window.location.search);
@@ -106,6 +110,10 @@ export default class Issues extends React.PureComponent<
       const params = getParamsFromProps(this.props);
       this.setState({ params });
       this.props.getIssues(params);
+      const scrolltoDiv = document.getElementById('scrollableDiv');
+      if(!!scrolltoDiv){
+        scrolltoDiv.scrollIntoView();
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Change

When navigating from home to the issues page from "TELL US A BIT ABOUT YOURSELF" section. The page was not scrolling to the top and starting somewhat scrolled down when Issues page loaded in Chrome. Also when you changed the filter on issues page it would not take you back to the top and you will stay where you are and new issues will be loaded and so, to view the top issues you have to scroll back up manually.

1. Fixed this bug by calling the scrollIntoView() function when the components mount in React. So page moves to the top as soon as it loads.

2. Also fixed the filter scroll bug by using the same inbuilt function whenever components update through the filter.

### Benefits

The transition from home to Issues page is smooth now and page starts from top when loaded. Also the when filters are changed, the page moves to the top from where the issues begin thus, improving user experience.


### Verification Process

Verified that the new changes are working in Chrome browser as expected, and the web app is working perfectly fine. Also tested the web app with new changes in Firefox and Edge and there is no problem in those browsers either.


### Applicable Issues

Closes #40 
