### PR TITLE
Fixed blocky scrolling when changing filters on issues page

### DIFF
--- a/src/routes/Issues/components/Issues.tsx
+++ b/src/routes/Issues/components/Issues.tsx
@@ -95,7 +95,7 @@ export default class Issues extends React.PureComponent<
   public componentDidMount(): void {
     const scrolltoRoot = document.getElementById('root');
     if(!!scrolltoRoot){
-      scrolltoRoot.scrollIntoView();
+      scrolltoRoot.scrollIntoView({ block: 'start',  behavior: 'smooth' });
     }
     this.props.getIssues(this.state.params);
     this.props.getProjects();
@@ -112,7 +112,7 @@ export default class Issues extends React.PureComponent<
       this.props.getIssues(params);
       const scrolltoDiv = document.getElementById('scrollableDiv');
       if(!!scrolltoDiv){
-        scrolltoDiv.scrollIntoView();
+        scrolltoDiv.scrollIntoView({ block: 'start',  behavior: 'smooth' });
       }
     }
   }
@@ -164,7 +164,7 @@ export default class Issues extends React.PureComponent<
                 </div>
               </div>
             </div>
-            <div className="col-md-8 col-12" id="scrollableDiv">
+            <div className="col-md-8 col-12 issuelist" id="scrollableDiv">
               <div className="d-flex justify-content-between mb-4">
                 <h2 className="col-12">
                   Showing {(page - 1) * 20}-{Math.min(page * 20, issuesLength)}{" "}

--- a/src/styles/issues.scss
+++ b/src/styles/issues.scss
@@ -16,6 +16,9 @@
     border-radius: 4px;
     box-shadow: inset 4px 0 0 0 #ff9696;
   }
+  .issuelist {
+    padding-top: 2em;
+  }
   .issue-card {
     background: #fff;
     border-radius: 4px;
@@ -115,7 +118,8 @@
   }
   .issues-filter-wrapper {
     display: none;
-    max-height: 80vh;
+    margin-top: 2em;
+    max-height: 92vh;
     overflow-y: hidden;
     @include media-breakpoint-up(md) {
       display: unset;


### PR DESCRIPTION
### Description of the Change

Fixed the blocky scrolling on issues page when changing filter, Also added some room to the top of the page, so when it scrolls to top the text dont touch the browser window.
Also increased the max height of filter sidebar so it spreads to the bottom and now it looks good in browser window.


### Benefits

The page scroll to top is smooth when changing filters now. also, improved user experience as no more blocky transitions. Larger filter wrapper makes the filter sidebar look good on the page.


### Verification Process

Tested the new look in firefox and chrome and it works as expected.

![new look](https://user-images.githubusercontent.com/26011845/47255198-be6a1a00-d48a-11e8-978f-007698a52dea.png)


### Concerning Issues
W.R.T. #16 
