### PR TITLE
links to cross origins made safe closes #17

### DIFF
--- a/src/components/FixMeNavbar/FixMeNavbar.tsx
+++ b/src/components/FixMeNavbar/FixMeNavbar.tsx
@@ -68,6 +68,7 @@ export default class FixMeNavbar extends React.Component<
                   target="_blank"
                   to="https://twitter.com/fixmeparser"
                   eventLabel="Twitter on menu clicked"
+                  rel="noopener noreferrer"
                 >
                   <FaTwitter />
                 </OutboundLink>

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -22,7 +22,7 @@ export const customPageView = (url: string) => {
 
 export const customOutboundLink = (url: string) =>
   develop
-    ? window.open(url, "_blank")
+    ? Object.assign(document.createElement('a'), { target: '_blank', href: url, rel: 'noopener noreferrer'}).click()
     : outboundLink({ label: url }, () => {
-        window.open(url, "_blank");
-      });
+      Object.assign(document.createElement('a'), { target: '_blank', href: 'http://google.com', rel: 'noopener noreferrer'}).click()
+    });


### PR DESCRIPTION
Closes #17 
Fixed Issue #17 making links to cross origins safe.
Attention given to that the link opens on the same tab using 
https://stackoverflow.com/questions/49276569/window-open-with-noopener-opens-a-new-window-instead-of-a-new-tab