### PR TITLE
Truncate project description to prevent title overlapping

### DIFF
--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -24,23 +24,33 @@ export const customPageView = (url: string) => {
 export const customOutboundLink = (url: string) => {
   if (develop || local) {
     const link = document.createElement("a");
-      link.setAttribute("href", url);
-      link.target = "_blank";
-      link.style.display = "none";
-      link.setAttribute('rel','noopener noreferrer')
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+    link.setAttribute("href", url);
+    link.target = "_blank";
+    link.style.display = "none";
+    link.setAttribute('rel', 'noopener noreferrer')
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   } else {
     outboundLink({ label: url }, () => {
       const link = document.createElement("a");
       link.setAttribute("href", url);
       link.target = "_blank";
       link.style.display = "none";
-      link.setAttribute('rel','noopener noreferrer')
+      link.setAttribute('rel', 'noopener noreferrer')
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link)
-     });
+    });
   }
 };
+
+export const truncate = (text: string, limit: number, suffix: string) => {
+  let content: string[]
+  text = text.trim();
+  // convert the text into a array of words and remove words beyond the limit
+  content = text.split(' ').slice(0, limit);
+
+  text = content.join(' ') + (suffix ? suffix : '');
+  return text;
+}

--- a/src/routes/Projects/components/Projects.tsx
+++ b/src/routes/Projects/components/Projects.tsx
@@ -4,7 +4,7 @@ import FixMeFooter from "../../../components/FixMeFooter/FixMeFooter";
 import FixMeMetas from "../../../components/FixMeMetas/FixMeMetas";
 import FixMeNavbar from "../../../components/FixMeNavbar/FixMeNavbar";
 import { shade } from "../../../helpers/colors";
-import { customPageView } from "../../../helpers/helpers";
+import { customPageView, truncate } from "../../../helpers/helpers";
 import notfound from '../../../images/notfound.png';
 import "../../../styles/projects.css";
 import { IProject } from "../modules/projectReducer";
@@ -109,7 +109,7 @@ export default class Projects extends React.PureComponent<IProjectProps, {}> {
                         </div>
                         <div className="projects-description">
                           <p className="projects-description-text">
-                            {description}
+                              {truncate(description, 30, "...")}
                           </p>
                         </div>
                       </div>

--- a/src/styles/projects.scss
+++ b/src/styles/projects.scss
@@ -65,7 +65,7 @@ $opacity: 0.3;
         z-index: 2;
       }
       &-top-title {
-        font-size: 1.8em;
+        font-size: 1.5em;
         line-height: 1em;
         margin-top: 0;
         text-align: left;


### PR DESCRIPTION
This resolves #108 by appending an ellipsis when the word count of the project description is > 30 (leaving enough room for the title to span multiple lines).